### PR TITLE
Link to storage form for external collaborator access

### DIFF
--- a/_doc/drive-external_collaborators.md
+++ b/_doc/drive-external_collaborators.md
@@ -5,6 +5,5 @@ categories: howto drive
 
 ### Instructions for UoA staff member to permit external collaborators to access research drives.
 
-First, follow the steps at [this link](https://superuoa.custhelp.com/app/answers/detail/a_id/8183/kw/university%20username%20for%20collaborators) to register a University username and enable network access for the external collaborator.
-
-Once that is done, send a request using the [ResearchHub storage request form](https://eresearch-dashboard.auckland.ac.nz/service/research-storage/request) to enable research drive access for the collaborator. Choose the "Existing" option on the first page.
+1.  Follow the instructions in [this article](https://superuoa.custhelp.com/app/answers/detail/a_id/8183/kw/university%20username%20for%20collaborators) and ensure all steps are completed.
+2.  Once the external collaborator has been set up and has working University credentials, the researcher should use [the Request or update storage form](https://research-hub.auckland.ac.nz/service/research-drive) to ask for the external collaborator to be given access to the specified Research Drive. The researcher will need to use the external collaborator's University of Auckland email address.

--- a/_doc/drive-external_collaborators.md
+++ b/_doc/drive-external_collaborators.md
@@ -5,11 +5,6 @@ categories: howto drive
 
 ### Instructions for UoA staff member to permit external collaborators to access research drives.
 
-Please follow the steps at [this link](https://superuoa.custhelp.com/app/answers/detail/a_id/8183/kw/university%20username%20for%20collaborators) to 
+First, follow the steps at [this link](https://superuoa.custhelp.com/app/answers/detail/a_id/8183/kw/university%20username%20for%20collaborators) to register a University username and enable network access for the external collaborator.
 
-1. Enable your external collaborator to register a UoA username
-
-2. Authorize the external collaborator to have access to your research drive
-
-
-Then you should open a ticket with Connect IT to request that  Centre of eResearch add the external collaborator to the drive's access group.
+Once that is done, send a request using the [ResearchHub storage request form](https://eresearch-dashboard.auckland.ac.nz/service/research-storage/request) to enable research drive access for the collaborator. Choose the "Existing" option on the first page.

--- a/_doc/drive-external_collaborators.md
+++ b/_doc/drive-external_collaborators.md
@@ -6,4 +6,4 @@ categories: howto drive
 ### Instructions for UoA staff member to permit external collaborators to access research drives.
 
 1.  Follow the instructions in [this article](https://superuoa.custhelp.com/app/answers/detail/a_id/8183/kw/university%20username%20for%20collaborators) and ensure all steps are completed.
-2.  Once the external collaborator has been set up and has working University credentials, the researcher should use [the Request or update storage form](https://research-hub.auckland.ac.nz/service/research-drive) to ask for the external collaborator to be given access to the specified Research Drive. The researcher will need to use the external collaborator's University of Auckland email address.
+2.  Once the external collaborator has been set up and has working University credentials, the researcher should use [the Request or update storage form](https://research-hub.auckland.ac.nz/service/research-drive) to ask for the external collaborator to be given access to the specified Research Drive.


### PR DESCRIPTION
This PR includes wording changes in the external collaborator page and link to request storage form.
The wording change clarifies that the article instructions do not authorise access for the research drive. It merely enables the external collaborator to have a University username and can access internal network resources.
It also links to the storage request form, which means the requests will go directly to us, rather than being sent through ServiceNow and possibly delayed in SSC queue.